### PR TITLE
Make `hasProperty` second argument optional

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -199,7 +199,7 @@ declare module "hamjest" {
 	export function hasProperties(matcher: { [key: string]: ValueOrMatcher }): Matcher;
 
 	// hasProperty: require('./matchers/IsObjectWithProperties').hasProperty,;
-	export function hasProperty(path: string, valueOrMatcher: ValueOrMatcher): Matcher;
+	export function hasProperty(path: string, valueOrMatcher?: ValueOrMatcher): Matcher;
 
 	// throws: require('./matchers/IsFunctionThrowing').throws,;
 	export function throws(): Matcher;

--- a/@types/typeTests.ts
+++ b/@types/typeTests.ts
@@ -82,6 +82,7 @@ _.assertThat('hamjest is awesome', _.anyOf(_.string(), _.containsString('hamjest
 // Object matcher
 _.assertThat({a: 'A', 0: 0}, _.hasProperties({ a: 'A', 0: 0 }));
 _.assertThat({a: 'A', 0: 0}, _.hasProperty('a', 'A'));
+_.assertThat({a: 'A', 0: 0}, _.hasProperty('a'));
 
 // Exception matcher
 _.assertThat(() => { throw new Error() }, _.throws());


### PR DESCRIPTION
As documented [here](https://github.com/rluba/hamjest/wiki/Matcher-documentation#haspropertyname-valueormatcher)